### PR TITLE
chore: update nginx max body size

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -119,6 +119,7 @@ kind: Ingress
 metadata:
   name: {{ project_name }}
   annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 30M
     nginx.ingress.kubernetes.io/whitelist-source-range: "{{ externalIngressAllowSourceIP|join(',') }}"
 spec:
   ingressClassName: nginx


### PR DESCRIPTION
Allow a larger max body size for image upload/search.

https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#custom-max-body-size

cc/ @gkartalis @admbtlr